### PR TITLE
Add AutoLabeler configuration

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -1,0 +1,3 @@
+documentation: ["*.md", "img"]
+chore: [".github", "LICENSE"]
+all-contributors: [".all-contributorsrc"]


### PR DESCRIPTION
Mostly for marking all-contributors PRs and merging them quickly